### PR TITLE
Suppress warnings from is_readable() when using open_basedir configuration

### DIFF
--- a/CryptoProvider.php
+++ b/CryptoProvider.php
@@ -20,7 +20,7 @@ class CryptoProvider implements ICryptoProvider {
         static $sources = array('/dev/urandom', '/dev/random');
 
         foreach ($sources as $source) {
-            if (is_readable($source)) {
+            if (@is_readable($source)) {
                 return bin2hex(file_get_contents($source, false, null, -1, $length / 2));
             }
         }


### PR DESCRIPTION
When configured with open_basedir a PHP Warning is generated each time readability is determined: 

````
    is_readable(): open_basedir restriction in effect. File(/dev/urandom) is not within the allowed path(s): (...) in vendor/kunststube/csrfp/Kunststube/CSRFP/CryptoProvider.php on line 23
````

This change should suppress these warnings, which should be fine since there is a fallback to using other sources for entropy. 